### PR TITLE
Add CORS config for GET reqs

### DIFF
--- a/qa-rest/src/main/java/ru/volpi/qarest/client/ApiCorsConfiguration.java
+++ b/qa-rest/src/main/java/ru/volpi/qarest/client/ApiCorsConfiguration.java
@@ -1,0 +1,25 @@
+package ru.volpi.qarest.client;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class ApiCorsConfiguration {
+
+    @Bean
+    public WebMvcConfigurer corsConfigurer() {
+        return new WebMvcConfigurer() {
+            @Override
+            public void addCorsMappings(final CorsRegistry registry) {
+                registry
+                    .addMapping("/**")
+                    .allowedOrigins("*")
+                    .allowedMethods("GET")
+                    .allowedHeaders("*");
+            }
+        };
+    }
+
+}


### PR DESCRIPTION
closes #44 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new class `ApiCorsConfiguration` to handle Cross-Origin Resource Sharing (CORS) configuration for the API.

### Detailed summary
- Added new class `ApiCorsConfiguration`
- Imported necessary classes from Spring Framework
- Defined `corsConfigurer` method to configure CORS settings
- Added mapping for all endpoints (`"/**"`)
- Allowed all origins (`"*"`)
- Allowed only GET method
- Allowed all headers (`"*"`)

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->