### PR TITLE
add ability to toggle password visibility

### DIFF
--- a/qa-admin/src/main/client/src/components/LoginForm.tsx
+++ b/qa-admin/src/main/client/src/components/LoginForm.tsx
@@ -5,7 +5,7 @@ import {PrimaryButton} from "./UI/PrimaryButton/PrimaryButton";
 import {BoltIcon} from "@heroicons/react/24/solid";
 import {useAppDispatch, useAppSelector} from "../hooks/redux";
 import {auth} from "../store/actions/authAction";
-import {ExclamationTriangleIcon} from "@heroicons/react/24/outline";
+import {ExclamationTriangleIcon, EyeIcon, EyeSlashIcon} from "@heroicons/react/24/outline";
 import {Loader} from "./UI/Loader";
 import {LoaderSize} from "../utils/getLoaderSizeByName";
 
@@ -17,12 +17,16 @@ export const LoginForm: FC = () => {
     const [username, setUsername] = useState("")
     const [isPasswordValid, setIsPasswordValid] = useState(false)
     const [password, setPassword] = useState("")
+    const [isShowPassword, setIsShowPassword] = useState(false)
     const {loading} = useAppSelector(state => state.auth)
     const dispatch = useAppDispatch()
     const formHandler = (e: FormEvent) => {
         e.preventDefault()
         if (!isUsernameValid || !isPasswordValid) return setShowValidation(true)
         dispatch(auth({username, password}))
+    }
+    const toggleIsShowPassword = () => {
+        setIsShowPassword(prev => !prev)
     }
     return (
         <form className={"w-64 p-4 border border-base/50 rounded-lg flex flex-col"} onSubmit={formHandler}>
@@ -40,15 +44,29 @@ export const LoginForm: FC = () => {
                     value={username}
                     onChange={(e) => setUsername(e.target.value)}
                     label={"Логин"}
+                    type={"text"}
                 />
-                <ValidatedInput
-                    validateFunc={validateInputValue}
-                    setIsValid={setIsPasswordValid}
-                    showValidation={showValidation}
-                    value={password}
-                    onChange={(e) => setPassword(e.target.value)}
-                    label={"Пароль"}
-                />
+                <div className={"relative"}>
+                    <ValidatedInput
+                        validateFunc={validateInputValue}
+                        setIsValid={setIsPasswordValid}
+                        showValidation={showValidation}
+                        value={password}
+                        type={isShowPassword ? "text" : "password"}
+                        onChange={(e) => setPassword(e.target.value)}
+                        label={"Пароль"}
+                        className={"pr-10"}
+                    />
+                    <div
+                        className={"absolute right-2 top-1/2 h-6 w-6 bg-secondary cursor-pointer hover:text-contrastHov"}
+                        onClick={toggleIsShowPassword}
+                    >
+                        {isShowPassword
+                            ? <EyeSlashIcon className={"w-5 h-5"}/>
+                            : <EyeIcon className={"w-5 h-5"}/>
+                        }
+                    </div>
+                </div>
             </div>
             <PrimaryButton type={"submit"} className={"flex items-center justify-center mt-8 min-h-[40px]"}>
                 {loading === "pending"

--- a/qa-admin/src/main/client/src/components/LoginForm.tsx
+++ b/qa-admin/src/main/client/src/components/LoginForm.tsx
@@ -17,7 +17,6 @@ export const LoginForm: FC = () => {
     const [username, setUsername] = useState("")
     const [isPasswordValid, setIsPasswordValid] = useState(false)
     const [password, setPassword] = useState("")
-    const [isShowPassword, setIsShowPassword] = useState(false)
     const {loading} = useAppSelector(state => state.auth)
     const dispatch = useAppDispatch()
     const formHandler = (e: FormEvent) => {
@@ -25,9 +24,7 @@ export const LoginForm: FC = () => {
         if (!isUsernameValid || !isPasswordValid) return setShowValidation(true)
         dispatch(auth({username, password}))
     }
-    const toggleIsShowPassword = () => {
-        setIsShowPassword(prev => !prev)
-    }
+
     return (
         <form className={"w-64 p-4 border border-base/50 rounded-lg flex flex-col"} onSubmit={formHandler}>
             {loading === "failed" &&
@@ -46,27 +43,15 @@ export const LoginForm: FC = () => {
                     label={"Логин"}
                     type={"text"}
                 />
-                <div className={"relative"}>
-                    <ValidatedInput
-                        validateFunc={validateInputValue}
-                        setIsValid={setIsPasswordValid}
-                        showValidation={showValidation}
-                        value={password}
-                        type={isShowPassword ? "text" : "password"}
-                        onChange={(e) => setPassword(e.target.value)}
-                        label={"Пароль"}
-                        className={"pr-10"}
-                    />
-                    <div
-                        className={"absolute right-2 top-1/2 h-6 w-6 bg-secondary cursor-pointer hover:text-contrastHov"}
-                        onClick={toggleIsShowPassword}
-                    >
-                        {isShowPassword
-                            ? <EyeSlashIcon className={"w-5 h-5"}/>
-                            : <EyeIcon className={"w-5 h-5"}/>
-                        }
-                    </div>
-                </div>
+                <ValidatedInput
+                    validateFunc={validateInputValue}
+                    setIsValid={setIsPasswordValid}
+                    showValidation={showValidation}
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                    label={"Пароль"}
+                    isPassword={true}
+                />
             </div>
             <PrimaryButton type={"submit"} className={"flex items-center justify-center mt-8 min-h-[40px]"}>
                 {loading === "pending"

--- a/qa-admin/src/main/client/src/components/UI/ValidatedInput/ValidatedInput.tsx
+++ b/qa-admin/src/main/client/src/components/UI/ValidatedInput/ValidatedInput.tsx
@@ -1,11 +1,13 @@
 import {FC, InputHTMLAttributes, useEffect, useState} from 'react';
 import {ValidateInputResult} from "../../../utils/createValidateInputValue/createValidateInputValueFunc";
+import {EyeIcon, EyeSlashIcon} from "@heroicons/react/24/outline";
 
 interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
     label?: string
     validateFunc: (inputValue: InputHTMLAttributes<HTMLInputElement>['value']) => ValidateInputResult
     setIsValid: (isValid: boolean) => void
     showValidation: boolean
+    isPassword?: boolean
 }
 
 export const ValidatedInput: FC<InputProps> = ({
@@ -15,10 +17,12 @@ export const ValidatedInput: FC<InputProps> = ({
                                                    validateFunc,
                                                    setIsValid,
                                                    showValidation,
+                                                   isPassword,
                                                    ...props
                                                }) => {
     const [inputStatusClasses, setInputStatusClasses] = useState("border-base/50")
     const [validateResult, setValidateResult] = useState<ValidateInputResult>("выглядит хорошо!")
+    const [isShowPassword, setIsShowPassword] = useState(false)
     useEffect(() => {
         setValidateResult(validateFunc(value))
     }, [value])
@@ -29,14 +33,29 @@ export const ValidatedInput: FC<InputProps> = ({
         setIsValid(isValid)
     }, [validateResult, showValidation])
 
+    const toggleIsShowPassword = () => {
+        setIsShowPassword(prev => !prev)
+    }
+
     return (
         <label className={"max-w-[250px]"}>
             {label && <div className={"text-pale text-sm ml-1"}>{label}</div>}
-            <input
-                className={`${className} px-4 py-2 rounded-lg outline-none bg-secondary border ${inputStatusClasses} w-full`}
-                value={value}
-                {...props}
-            />
+            <div className={`rounded-lg flex items-center bg-secondary border ${inputStatusClasses}`}>
+                <input
+                    className={`${className} px-4 py-2 bg-transparent outline-none w-full`}
+                    value={value}
+                    type={!isShowPassword && isPassword ? "password" : "text"}
+                    {...props}
+                />
+                {isPassword &&
+                    <div className={"mr-4 cursor-pointer"} onClick={toggleIsShowPassword}>
+                        {isShowPassword
+                            ? <EyeSlashIcon className={"w-5 h-5 hover:text-contrastHov"}/>
+                            : <EyeIcon className={"w-5 h-5 hover:text-contrastHov"}/>
+                        }
+                    </div>
+                }
+            </div>
             {showValidation && <div
                 className={`text-sm ${validateResult === "выглядит хорошо!" ? "text-safe/80" : "text-danger/80"}`}>{validateResult}</div>}
         </label>


### PR DESCRIPTION
Closes #63

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a feature to show/hide the password in the login form. 

### Detailed summary
- Added EyeIcon and EyeSlashIcon from "@heroicons/react/24/outline"
- Added `isPassword` prop to ValidatedInput component
- Added `isShowPassword` state to toggle password visibility
- Added `toggleIsShowPassword` function to toggle `isShowPassword` state
- Changed input type to "password" if `isPassword` is true and `isShowPassword` is false
- Added EyeIcon and EyeSlashIcon to show/hide password in ValidatedInput component

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->