### PR TITLE
Fix #67, Not allow empty username/password

### DIFF
--- a/qa-admin/src/main/java/ru/volpi/qaadmin/dto/user/AuthenticationRequest.java
+++ b/qa-admin/src/main/java/ru/volpi/qaadmin/dto/user/AuthenticationRequest.java
@@ -1,5 +1,6 @@
 package ru.volpi.qaadmin.dto.user;
 
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 
 import static ru.volpi.qaadmin.validation.message.UserMessages.NAME_CANT_BE_EMPTY;
@@ -7,6 +8,6 @@ import static ru.volpi.qaadmin.validation.message.UserMessages.PASSWORD_CANT_BE_
 
 public record AuthenticationRequest(
     @NotEmpty(message = NAME_CANT_BE_EMPTY) String username,
-    @NotEmpty(message = PASSWORD_CANT_BE_EMPTY) String password
+    @NotBlank(message = PASSWORD_CANT_BE_EMPTY) String password
 ) {
 }

--- a/qa-admin/src/main/java/ru/volpi/qaadmin/exception/user/UserValidationException.java
+++ b/qa-admin/src/main/java/ru/volpi/qaadmin/exception/user/UserValidationException.java
@@ -1,0 +1,18 @@
+package ru.volpi.qaadmin.exception.user;
+
+import jakarta.validation.ConstraintViolation;
+
+import java.io.Serial;
+import java.util.Collection;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class UserValidationException extends RuntimeException {
+    @Serial
+    private static final long serialVersionUID = -8095479712817681679L;
+
+    public UserValidationException(final Collection<ConstraintViolation<Object>> violations) {
+        super(violations.stream().map(ConstraintViolation::getMessage)
+            .collect(Collectors.joining("\n")));
+    }
+}


### PR DESCRIPTION
closes #67 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds validation to the user authentication and registration process, ensuring that the required fields are not empty or blank.

### Detailed summary
- Added `@NotBlank` validation to the `password` field in `AuthenticationRequest`
- Created `UserValidationException` to handle validation errors
- Added `Validator` to `AuthService` to validate user input
- Checked for validation errors in `register` method of `AuthService` and threw `UserValidationException` if any were found

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->