### PR TITLE
Allow swagger to unauthorized user

### DIFF
--- a/qa-admin/src/main/java/ru/volpi/qaadmin/web/controller/AuthRestController.java
+++ b/qa-admin/src/main/java/ru/volpi/qaadmin/web/controller/AuthRestController.java
@@ -1,8 +1,14 @@
 package ru.volpi.qaadmin.web.controller;
 
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.models.annotations.OpenAPI31;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 import ru.volpi.qaadmin.dto.user.AuthenticationRequest;
 import ru.volpi.qaadmin.dto.user.AuthenticationResponse;
 import ru.volpi.qaadmin.service.impl.AuthService;

--- a/qa-admin/src/main/java/ru/volpi/qaadmin/web/security/config/SecurityConfig.java
+++ b/qa-admin/src/main/java/ru/volpi/qaadmin/web/security/config/SecurityConfig.java
@@ -35,7 +35,13 @@ public class SecurityConfig {
             .disable()
             .cors(Customizer.withDefaults())
             .authorizeHttpRequests()
-            .requestMatchers("/api/v1/admin/auth/**", "/api/v1/admin/register/**")
+            .requestMatchers(
+                "/api/v1/admin/auth/**",
+                "/api/v1/admin/register/**",
+                "/v3/api-docs/**",
+                "/swagger-ui/**",
+                "/swagger-ui.html"
+            )
             .permitAll()
             .requestMatchers("/api/v1/admin/**")
             .authenticated()


### PR DESCRIPTION
closes #66 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds Swagger UI and OpenAPI 3.1 support to the application and updates the security configuration to permit access to the Swagger UI endpoints. 

### Detailed summary
- Added import statements for Swagger and OpenAPI 3.1
- Added `@CrossOrigin` annotation to `AuthRestController`
- Added `@PostMapping` annotation to `AuthRestController`
- Added `@RequestMapping` annotation to `AuthRestController`
- Added `@RestController` annotation to `AuthRestController`
- Added Swagger UI endpoints to the security configuration in `SecurityConfig.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->