### PR TITLE
clear questions when leaving categoryName page

### DIFF
--- a/qa-admin/src/main/client/src/pages/CategoryName.tsx
+++ b/qa-admin/src/main/client/src/pages/CategoryName.tsx
@@ -11,6 +11,7 @@ import {ValidatedInput} from "../components/UI/ValidatedInput/ValidatedInput";
 import {createValidateInputValueFunc} from "../utils/createValidateInputValue/createValidateInputValueFunc";
 import {PencilSquareIcon} from "@heroicons/react/24/outline";
 import {fetchCategories, updateCategory} from "../store/actions/categoryAction";
+import {clearQuestions} from "../store/reducers/questionSlice";
 
 const CategoryName: FC = () => {
     const navigate = useNavigate()
@@ -32,6 +33,7 @@ const CategoryName: FC = () => {
         dispatch(fetchQuestionsByCategory(name))
         return () => {
             dispatch(clearCurrentCategory())
+            dispatch(clearQuestions())
         }
     }, [])
 

--- a/qa-admin/src/main/client/src/store/reducers/questionSlice.ts
+++ b/qa-admin/src/main/client/src/store/reducers/questionSlice.ts
@@ -24,7 +24,11 @@ const initialState: QuestionState = {
 const questionSlice = createSlice({
     name: "question",
     initialState,
-    reducers: {},
+    reducers: {
+        clearQuestions(state){
+            state.questions = []
+        }
+    },
     extraReducers: (builder) => {
         builder.addCase(fetchAllQuestions.pending, (state) => {
             state.loading = "pending"
@@ -86,3 +90,5 @@ const questionSlice = createSlice({
 })
 
 export default questionSlice.reducer
+
+export const {clearQuestions} = questionSlice.actions


### PR DESCRIPTION
Closes #72 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new action to the `questionSlice` reducer and invokes it in `CategoryName` component to clear the questions array when the component unmounts.

### Detailed summary
- Adds a new action `clearQuestions` to the `questionSlice` reducer.
- Invokes `clearQuestions` action in `CategoryName` component to clear the questions array when the component unmounts.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->