### PR TITLE
Display num of category, instead of id

### DIFF
--- a/qa-admin/src/main/client/src/components/categories/CategoriesList/CategoriesList.tsx
+++ b/qa-admin/src/main/client/src/components/categories/CategoriesList/CategoriesList.tsx
@@ -19,8 +19,8 @@ export const CategoriesList: FC<CategoriesListProps> = ({testID}) => {
         <div className={"rounded-lg w-full"} data-testid={testID}>
             <CategoriesListHead/>
             <ul>
-                {categories.map(c => (
-                    <CategoryRow key={c.id} id={c.id} name={c.name} testID={categoryRowTestID}/>
+                {categories.map((c, i) => (
+                    <CategoryRow key={c.id} id={c.id} name={c.name} testID={categoryRowTestID} num={i + 1}/>
                 ))}
             </ul>
         </div>

--- a/qa-admin/src/main/client/src/components/categories/CategoriesListHead.tsx
+++ b/qa-admin/src/main/client/src/components/categories/CategoriesListHead.tsx
@@ -3,7 +3,7 @@ import {FC} from 'react';
 export const CategoriesListHead: FC = () => {
     return (
         <div className={"flex items-center px-4 pb-2 text-pale"}>
-            <div className={"w-10 text-pale border-r border-base/50"}>id</div>
+            <div className={"w-10 text-pale border-r border-base/50"}>№</div>
             <div className={"pl-2"}>Название</div>
         </div>
     );

--- a/qa-admin/src/main/client/src/components/categories/CategoryRow/CategoryRow.test.tsx
+++ b/qa-admin/src/main/client/src/components/categories/CategoryRow/CategoryRow.test.tsx
@@ -9,20 +9,21 @@ import {CategoryRowTestID} from "../../../constants/testIDs";
 
 describe("CategoryRow", () => {
     const idProp = 321
+    const numProp = 985
     const nameProp = "some category username"
     const {queryByText} = render(
         <Provider store={createStore()}>
             <BrowserRouter>
-                <CategoryRow id={idProp} name={nameProp} testID={CategoryRowTestID}/>
+                <CategoryRow id={idProp} name={nameProp} testID={CategoryRowTestID} num={numProp}/>
             </BrowserRouter>
         </Provider>
     )
     const liElement = screen.getByTestId(CategoryRowTestID)
 
     it("correctly render props", () => {
-        const id = queryByText(idProp)
+        const num = queryByText(numProp)
         const name = queryByText(nameProp)
-        expect(id).toBeInTheDocument()
+        expect(num).toBeInTheDocument()
         expect(name).toBeInTheDocument()
     })
 

--- a/qa-admin/src/main/client/src/components/categories/CategoryRow/CategoryRow.tsx
+++ b/qa-admin/src/main/client/src/components/categories/CategoryRow/CategoryRow.tsx
@@ -9,9 +9,10 @@ import {PrimaryButton} from "../../UI/PrimaryButton/PrimaryButton";
 
 interface CategoryRowProps extends ICategoryNoQuestions {
     testID?: string
+    num: number
 }
 
-export const CategoryRow: FC<CategoryRowProps> = ({id, name, testID}) => {
+export const CategoryRow: FC<CategoryRowProps> = ({id, name, testID, num}) => {
     const dispatch = useAppDispatch()
     const deleteBtnHandler = async () => {
         await dispatch(deleteCategory(id))
@@ -23,7 +24,7 @@ export const CategoryRow: FC<CategoryRowProps> = ({id, name, testID}) => {
             className={"even:bg-secondaryEven flex justify-between rounded-lg items-center hover:bg-primaryHov px-4"}
         >
             <Link to={"/categories/" + name} className={"flex w-full py-2"}>
-                <div className={"w-10 text-pale"}>{id}</div>
+                <div className={"w-10 text-pale"}>{num}</div>
                 <div className={"pl-2"}>{name}</div>
             </Link>
             <Popup


### PR DESCRIPTION
Closes #77 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a numbering system to the categories list in the QA admin page.

### Detailed summary
- Adds a `num` prop to `CategoryRow` component to display the category number.
- Updates `CategoriesList` to pass the `num` prop to `CategoryRow`.
- Updates `CategoriesListHead` to replace "id" with "№".

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->