### PR TITLE
87

### DIFF
--- a/qa-admin/src/main/client/.gitignore
+++ b/qa-admin/src/main/client/.gitignore
@@ -25,3 +25,6 @@ coverage
 *.sln
 *.sw?
 
+# Environment variables
+.env
+

--- a/qa-admin/src/main/client/src/constants/api.ts
+++ b/qa-admin/src/main/client/src/constants/api.ts
@@ -1,1 +1,1 @@
-export const API_URL = import.meta.env.VITE_API_URL
+export const API_URL = import.meta.env.VITE_API_URL || "http://localhost:8080/api/v1/admin"

--- a/qa-admin/src/main/client/src/constants/api.ts
+++ b/qa-admin/src/main/client/src/constants/api.ts
@@ -1,1 +1,1 @@
-export const API_URL = "http://localhost:8080/api/v1/admin"
+export const API_URL = import.meta.env.VITE_API_URL

--- a/qa-admin/src/main/client/src/constants/api.ts
+++ b/qa-admin/src/main/client/src/constants/api.ts
@@ -1,1 +1,1 @@
-export const API_URL = import.meta.env.VITE_API_URL || "http://localhost:8080/api/v1/admin"
+export const API_URL = import.meta.env.VITE_ADMIN_API_URL || "http://localhost:8080/api/v1/admin"

--- a/qa-rest/src/main/client/.gitignore
+++ b/qa-rest/src/main/client/.gitignore
@@ -22,3 +22,7 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Environment variables
+.env
+

--- a/qa-rest/src/main/client/src/constants/api.ts
+++ b/qa-rest/src/main/client/src/constants/api.ts
@@ -1,1 +1,1 @@
-export const BASE_API_URL = "http://localhost:8081/api/v1"
+export const API_URL = import.meta.env.VITE_API_URL || "http://localhost:8081/api/v1/admin"

--- a/qa-rest/src/main/client/src/constants/api.ts
+++ b/qa-rest/src/main/client/src/constants/api.ts
@@ -1,1 +1,1 @@
-export const API_URL = import.meta.env.VITE_API_URL || "http://localhost:8081/api/v1"
+export const API_URL = import.meta.env.VITE_REST_API_URL || "http://localhost:8081/api/v1"

--- a/qa-rest/src/main/client/src/constants/api.ts
+++ b/qa-rest/src/main/client/src/constants/api.ts
@@ -1,1 +1,1 @@
-export const API_URL = import.meta.env.VITE_API_URL || "http://localhost:8081/api/v1/admin"
+export const API_URL = import.meta.env.VITE_API_URL || "http://localhost:8081/api/v1"

--- a/qa-rest/src/main/client/src/http/api.ts
+++ b/qa-rest/src/main/client/src/http/api.ts
@@ -1,6 +1,6 @@
 import axios from "axios";
-import {BASE_API_URL} from "../constants/api";
+import {API_URL} from "../constants/api";
 
 export const $api = axios.create({
-    baseURL: BASE_API_URL
+    baseURL: API_URL
 })


### PR DESCRIPTION
Closes #87

**Basic usage:**
- dev:
```bash
VITE_ADMIN_API_URL=<url> npm run dev
```
- production:
```bash
VITE_ADMIN_API_URL=<url> npm run build
```
- or just type 
```bash
npm run dev
```
and it will get default url, i.e. `http://localhost:8080/api/v1/admin`, same thing for rest-app

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the API URL in the client code of two applications. 

### Detailed summary
- Added `.env` to both client `.gitignore` files
- Updated the `API_URL` constant in `qa-rest/src/main/client/src/constants/api.ts` to use the environment variable `VITE_API_URL` or default to `http://localhost:8081/api/v1`
- Updated the `API_URL` constant in `qa-admin/src/main/client/src/constants/api.ts` to use the environment variable `VITE_API_URL` or default to `http://localhost:8080/api/v1/admin`
- Updated the `baseURL` property in `qa-rest/src/main/client/src/http/api.ts` to use the updated `API_URL` constant instead of the old `BASE_API_URL` constant.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->