### PR TITLE
fix bug with error display

### DIFF
--- a/qa-admin/src/main/client/src/components/auth/LoginForm.tsx
+++ b/qa-admin/src/main/client/src/components/auth/LoginForm.tsx
@@ -31,7 +31,7 @@ export const LoginForm: FC = () => {
 
     return (
         <>
-            {loading === "failed" || !isTokenValid && error &&
+            {error && (loading === "failed" || !isTokenValid) &&
                 <div className={"text-danger flex items-center justify-center mb-3 gap-2"}>
                     <ExclamationTriangleIcon className={"w-5 h-5"}/>
                     <span>{error}</span>


### PR DESCRIPTION
Closes #92

<!-- start pr-codex -->

---

## PR-Codex overview
This PR changes the order of conditions in a ternary operator in `LoginForm.tsx` to fix an issue where an error message was not displayed correctly.

### Detailed summary
- Changed order of conditions in ternary operator in `LoginForm.tsx`.
- Error message now displays correctly when `loading` is "failed" or `isTokenValid` is false.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->