### PR TITLE
fix border color when validation should not shown

### DIFF
--- a/qa-admin/src/main/client/src/components/UI/ValidatedInput/ValidatedInput.tsx
+++ b/qa-admin/src/main/client/src/components/UI/ValidatedInput/ValidatedInput.tsx
@@ -29,7 +29,9 @@ export const ValidatedInput: FC<InputProps> = ({
 
     useEffect(() => {
         const isValid = validateResult === "выглядит хорошо!"
-        if (showValidation) setInputStatusClasses(isValid ? "border-safe/50" : "border-danger/50")
+        showValidation
+            ? setInputStatusClasses(isValid ? "border-safe/50" : "border-danger/50")
+            : setInputStatusClasses("border-base/50")
         setIsValid(isValid)
     }, [validateResult, showValidation])
 


### PR DESCRIPTION
Closes #95 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the ValidatedInput component by adding conditional logic to setInputStatusClasses based on the showValidation prop.

### Detailed summary
- Added conditional logic to setInputStatusClasses based on the showValidation prop
- If showValidation is true, setInputStatusClasses will be either "border-safe/50" or "border-danger/50" depending on the value of isValid
- If showValidation is false, setInputStatusClasses will be set to "border-base/50"
- This change improves the visual feedback for users when input validation is enabled.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->