### PR TITLE
fix updating category name

### DIFF
--- a/qa-admin/src/main/client/src/store/reducers/categorySlice.ts
+++ b/qa-admin/src/main/client/src/store/reducers/categorySlice.ts
@@ -61,8 +61,9 @@ const categorySlice = createSlice({
 
         builder.addCase(updateCategory.pending, (state) => {
             state.loading = "pending"
-        }).addCase(updateCategory.fulfilled, (state) => {
+        }).addCase(updateCategory.fulfilled, (state, action) => {
             state.loading = "succeeded"
+            state.currentCategory = action.payload
         }).addCase(updateCategory.rejected, (state, action) => {
             state.loading = "failed"
             console.log(action.error)


### PR DESCRIPTION
Closes #109

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the categorySlice reducer in the qa-admin client to handle the updateCategory action payload.

### Detailed summary
- The `updateCategory.fulfilled` case now sets the `state.currentCategory` to the `action.payload`.
- No other notable changes were made.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->