### PR TITLE
133

### DIFF
--- a/qa-admin/src/main/client/src/components/questions/Question.tsx
+++ b/qa-admin/src/main/client/src/components/questions/Question.tsx
@@ -9,6 +9,7 @@ import {Popup} from "../UI/Popup";
 import {createValidateInputValueFunc} from "../../utils/createValidateInputValue/createValidateInputValueFunc";
 import {ValidatedTextarea} from "../UI/ValidatedTextarea";
 import {CheckIcon, NoSymbolIcon} from "@heroicons/react/20/solid";
+import {parseLinks} from "../../utils/parseLinks/parseLinks";
 
 interface QuestionProps {
     question: IQuestion
@@ -93,8 +94,14 @@ export const Question: FC<QuestionProps> = ({question}) => {
                 </div>
                 : <>
                     <div>
-                        <div className={"text-xl"}>{question.text}</div>
-                        <div className={"text-pale"}>{question.answer}</div>
+                        <div
+                            className={"text-xl"}
+                            dangerouslySetInnerHTML={{__html: parseLinks(question.text)}}
+                        ></div>
+                        <div
+                            className={""}
+                            dangerouslySetInnerHTML={{__html: parseLinks(question.answer)}}
+                        ></div>
                     </div>
                     <div className={"flex items-start space-x-2"}>
                         <div

--- a/qa-admin/src/main/client/src/utils/parseLinks/parseLinks.test.ts
+++ b/qa-admin/src/main/client/src/utils/parseLinks/parseLinks.test.ts
@@ -5,19 +5,19 @@ describe("parseLinks", () => {
     it.each([
         [
             "losos karas https://volpi.ru/sveden/education",
-            "losos karas <a href='https://volpi.ru/sveden/education'>https://volpi.ru/sveden/education</a>"
+            "losos karas <a href='https://volpi.ru/sveden/education' class=\"text-link hover:text-linkHov text-base bg-secondary p-0.5 border border-border/40 rounded\">volpi.ru/sveden/education</a>"
         ],
         [
             "https://volpi.ru/sveden/education losos karas",
-            "<a href='https://volpi.ru/sveden/education'>https://volpi.ru/sveden/education</a> losos karas"
+            "<a href='https://volpi.ru/sveden/education' class=\"text-link hover:text-linkHov text-base bg-secondary p-0.5 border border-border/40 rounded\">volpi.ru/sveden/education</a> losos karas"
         ],
         [
             "https://volpi.ru/losos/karas",
-            "<a href='https://volpi.ru/losos/karas'>https://volpi.ru/losos/karas</a>"
+            "<a href='https://volpi.ru/losos/karas' class=\"text-link hover:text-linkHov text-base bg-secondary p-0.5 border border-border/40 rounded\">volpi.ru/losos/karas</a>"
         ],
         [
             "sdlkf sdf ksa https://volpi.ru/losos/karas asdlfk",
-            "sdlkf sdf ksa <a href='https://volpi.ru/losos/karas'>https://volpi.ru/losos/karas</a> asdlfk"
+            "sdlkf sdf ksa <a href='https://volpi.ru/losos/karas' class=\"text-link hover:text-linkHov text-base bg-secondary p-0.5 border border-border/40 rounded\">volpi.ru/losos/karas</a> asdlfk"
         ]
     ])("text: '%s' should return '%s'", (text: string, expected: string) => {
         expect(parseLinks(text)).toBe(expected)

--- a/qa-admin/src/main/client/src/utils/parseLinks/parseLinks.test.ts
+++ b/qa-admin/src/main/client/src/utils/parseLinks/parseLinks.test.ts
@@ -18,6 +18,10 @@ describe("parseLinks", () => {
         [
             "sdlkf sdf ksa https://volpi.ru/losos/karas asdlfk",
             "sdlkf sdf ksa <a href='https://volpi.ru/losos/karas' class=\"text-link hover:text-linkHov text-base bg-secondary p-0.5 border border-border/40 rounded\">volpi.ru/losos/karas</a> asdlfk"
+        ],
+        [
+            "some big link vk.com/fjhasdkjfhajksdhfkadshkfhasjdkhfjkashdfkhkajsdfhasjkdhfkjashdjkfhaksjhdfkjhasdhfkjahsdkfljhaskjdhfkjhasd",
+            "some big link <a href='http://vk.com/fjhasdkjfhajksdhfkadshkfhasjdkhfjkashdfkhkajsdfhasjkdhfkjashdjkfhaksjhdfkjhasdhfkjahsdkfljhaskjdhfkjhasd\' class=\"text-link hover:text-linkHov text-base bg-secondary p-0.5 border border-border/40 rounded\">vk.com/fjhasdkjfhajksdhfkadshkfhasjdkhfj...</a>"
         ]
     ])("text: '%s' should return '%s'", (text: string, expected: string) => {
         expect(parseLinks(text)).toBe(expected)

--- a/qa-admin/src/main/client/src/utils/parseLinks/parseLinks.test.ts
+++ b/qa-admin/src/main/client/src/utils/parseLinks/parseLinks.test.ts
@@ -1,0 +1,25 @@
+import {describe, it, expect} from "vitest"
+import {parseLinks} from "./parseLinks";
+
+describe("parseLinks", () => {
+    it.each([
+        [
+            "losos karas https://volpi.ru/sveden/education",
+            "losos karas <a href='https://volpi.ru/sveden/education'>https://volpi.ru/sveden/education</a>"
+        ],
+        [
+            "https://volpi.ru/sveden/education losos karas",
+            "<a href='https://volpi.ru/sveden/education'>https://volpi.ru/sveden/education</a> losos karas"
+        ],
+        [
+            "https://volpi.ru/losos/karas",
+            "<a href='https://volpi.ru/losos/karas'>https://volpi.ru/losos/karas</a>"
+        ],
+        [
+            "sdlkf sdf ksa https://volpi.ru/losos/karas asdlfk",
+            "sdlkf sdf ksa <a href='https://volpi.ru/losos/karas'>https://volpi.ru/losos/karas</a> asdlfk"
+        ]
+    ])("text: '%s' should return '%s'", (text: string, expected: string) => {
+        expect(parseLinks(text)).toBe(expected)
+    });
+})

--- a/qa-admin/src/main/client/src/utils/parseLinks/parseLinks.ts
+++ b/qa-admin/src/main/client/src/utils/parseLinks/parseLinks.ts
@@ -1,0 +1,4 @@
+export const parseLinks = (text: string) => {
+    const urlRegex = /https?:\/\/[^\s]+/g;
+    return text.replace(urlRegex, (url) => `<a href='${url}'>${url}</a>`);
+}

--- a/qa-admin/src/main/client/src/utils/parseLinks/parseLinks.ts
+++ b/qa-admin/src/main/client/src/utils/parseLinks/parseLinks.ts
@@ -1,4 +1,7 @@
 export const parseLinks = (text: string) => {
-    const urlRegex = /https?:\/\/[^\s]+/g;
-    return text.replace(urlRegex, (url) => `<a href='${url}'>${url}</a>`);
+    const urlRegex = /(?:https?:\/\/)?(?:www\.)?([^\s]+(\.ru|\.com)[^\s]*)/g;
+    return text.replace(urlRegex, (url, domainAndPath) => {
+        const fullUrl = url.startsWith('http') ? url : `http://${url}`;
+        return `<a href='${fullUrl}' class="text-link hover:text-linkHov text-base bg-secondary p-0.5 border border-border/40 rounded">${domainAndPath}</a>`;
+    });
 }

--- a/qa-admin/src/main/client/src/utils/parseLinks/parseLinks.ts
+++ b/qa-admin/src/main/client/src/utils/parseLinks/parseLinks.ts
@@ -1,7 +1,8 @@
 export const parseLinks = (text: string) => {
     const urlRegex = /(?:https?:\/\/)?(?:www\.)?([^\s]+(\.ru|\.com)[^\s]*)/g;
-    return text.replace(urlRegex, (url, domainAndPath) => {
+    return text.replace(urlRegex, (url:string, domainAndPath:string) => {
         const fullUrl = url.startsWith('http') ? url : `http://${url}`;
+        if(domainAndPath.length > 40) domainAndPath = domainAndPath.slice(0, 40) + "..."
         return `<a href='${fullUrl}' class="text-link hover:text-linkHov text-base bg-secondary p-0.5 border border-border/40 rounded">${domainAndPath}</a>`;
     });
 }

--- a/qa-admin/src/main/client/tailwind.config.cjs
+++ b/qa-admin/src/main/client/tailwind.config.cjs
@@ -22,7 +22,9 @@ module.exports = {
                 border: colors.neutral["500"],
                 contrast: colors.neutral["100"],
                 contrastHov: colors.neutral["300"],
-                shadow: colors.black
+                shadow: colors.black,
+                link: colors.indigo[400],
+                linkHov:colors.indigo[500]
             },
         },
     },

--- a/qa-rest/src/main/client/src/components/Question.tsx
+++ b/qa-rest/src/main/client/src/components/Question.tsx
@@ -2,18 +2,26 @@ import {FC} from "react"
 import {IQuestion} from "../types/IQuestion";
 import {Disclosure} from "@headlessui/react";
 import {ChevronDownIcon} from "@heroicons/react/24/outline";
+import {parseLinks} from "../utils/parseLinks";
 
 export const Question: FC<Omit<IQuestion, "id" | "category">> = ({text, answer}) => {
     return (
         <Disclosure>
             <div
                 className={"w-full flex justify-center flex-col"}>
-                <Disclosure.Button className={"p-2 flex justify-between items-center bg-neutral-100 hover:bg-neutral-200 rounded-lg"}>
-                    <div className={"font-medium text-left w-5/6"}>{text}</div>
+                <Disclosure.Button
+                    className={"p-2 flex justify-between items-center bg-neutral-100 hover:bg-neutral-200 rounded-lg"}>
+                    <div
+                        className={"font-medium text-left w-5/6"}
+                        dangerouslySetInnerHTML={{__html: parseLinks(text)}}
+                    ></div>
                     <ChevronDownIcon
                         className={"w-4 h-4 ml-2 ui-open:rotate-180 ui-not-open:rotate-0 ui-open:transform ui-open:duration-150"}/>
                 </Disclosure.Button>
-                <Disclosure.Panel className={"px-2 pt-2 text-neutral-900/60 text-sm"}>{answer}</Disclosure.Panel>
+                <Disclosure.Panel
+                    className={"px-2 pt-2 text-neutral-900/60 text-sm"}
+                    dangerouslySetInnerHTML={{__html: parseLinks(answer)}}
+                ></Disclosure.Panel>
             </div>
         </Disclosure>
     );

--- a/qa-rest/src/main/client/src/utils/parseLinks.ts
+++ b/qa-rest/src/main/client/src/utils/parseLinks.ts
@@ -3,6 +3,6 @@ export const parseLinks = (text: string) => {
     return text.replace(urlRegex, (url, domainAndPath) => {
         const fullUrl = url.startsWith('http') ? url : `http://${url}`;
         if(domainAndPath.length > 30) domainAndPath = domainAndPath.slice(0, 27) + "..."
-        return `<a href='${fullUrl}' class="text-indigo-600 break-words hover:text-indigo-500 text-base bg-indigo-100 p-0.5 rounded">${domainAndPath}</a>`;
+        return `<a href='${fullUrl}' class="text-indigo-600 break-words hover:text-indigo-500 font-medium text-base bg-indigo-100 p-0.5 rounded">${domainAndPath}</a>`;
     });
 }

--- a/qa-rest/src/main/client/src/utils/parseLinks.ts
+++ b/qa-rest/src/main/client/src/utils/parseLinks.ts
@@ -1,0 +1,8 @@
+export const parseLinks = (text: string) => {
+    const urlRegex = /(?:https?:\/\/)?(?:www\.)?([^\s]+(\.ru|\.com)[^\s]*)/g;
+    return text.replace(urlRegex, (url, domainAndPath) => {
+        const fullUrl = url.startsWith('http') ? url : `http://${url}`;
+        if(domainAndPath.length > 30) domainAndPath = domainAndPath.slice(0, 27) + "..."
+        return `<a href='${fullUrl}' class="text-indigo-600 break-words hover:text-indigo-500 text-base bg-indigo-100 p-0.5 rounded">${domainAndPath}</a>`;
+    });
+}


### PR DESCRIPTION
Closes #133

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a `parseLinks` utility function to parse links in question and answer texts, and style them as HTML anchors. It also adds new colors and styles to the `tailwind.config.cjs` file.

### Detailed summary
- Added `parseLinks` utility function to parse links in question and answer texts and style them as HTML anchors.
- Updated `tailwind.config.cjs` with new colors and styles for `shadow`, `link`, and `linkHov`.
- Updated `Question` and `qa-admin/src/main/client/src/components/questions/Question.tsx` to use `parseLinks` for question and answer texts.
- Added tests for `parseLinks` utility function in `qa-admin/src/main/client/src/utils/parseLinks/parseLinks.test.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->