### PR TITLE
fix layout duplication on load

### DIFF
--- a/qa-rest/src/main/client/src/components/views/DefaultView.tsx
+++ b/qa-rest/src/main/client/src/components/views/DefaultView.tsx
@@ -1,9 +1,7 @@
 import {FC, useEffect} from "react"
 import {CategoryOption} from "../CategoryOption";
-import {ICategory} from "../../types/ICategory";
 import {useAppDispatch, useAppSelector} from "../../hooks/redux";
 import {fetchAllCategories} from "../../store/actions/categoryAction";
-import {Layout} from "../Layout";
 import {Loader} from "../UI/Loader";
 
 export const DefaultView: FC = () => {

--- a/qa-rest/src/main/client/src/components/views/DefaultView.tsx
+++ b/qa-rest/src/main/client/src/components/views/DefaultView.tsx
@@ -12,7 +12,7 @@ export const DefaultView: FC = () => {
     useEffect(() => {
         dispatch(fetchAllCategories())
     }, [])
-    if(loading === "pending" && categories.length === 0) return <Layout><Loader/></Layout>
+    if(loading === "pending" && categories.length === 0) return <Loader/>
 
     return (
         <>


### PR DESCRIPTION
Closes #138

<!-- start pr-codex -->

---

## PR-Codex overview
This PR removes an unused import and simplifies the loading spinner logic in DefaultView component.

### Detailed summary
- Remove unused import of `ICategory`
- Simplify loading spinner logic by removing `Layout` wrapper when there are no categories to display.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->