### PR TITLE
Admin addition answer to unknown question

### DIFF
--- a/qa-admin/src/main/java/ru/volpi/qaadmin/domain/question/Questions.java
+++ b/qa-admin/src/main/java/ru/volpi/qaadmin/domain/question/Questions.java
@@ -6,7 +6,7 @@ import ru.volpi.qaadmin.dto.question.QuestionRegistration;
 import ru.volpi.qaadmin.dto.question.QuestionUpdate;
 
 @UtilityClass
-public class Questions {
+public final class Questions {
     public static Question of(final Long id, final QuestionUpdate update) {
         return Question.builder()
             .id(id)

--- a/qa-admin/src/main/java/ru/volpi/qaadmin/domain/question/UnknownQuestion.java
+++ b/qa-admin/src/main/java/ru/volpi/qaadmin/domain/question/UnknownQuestion.java
@@ -1,0 +1,33 @@
+package ru.volpi.qaadmin.domain.question;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "unknown_questions", schema = "unknown_questions_storage")
+public class UnknownQuestion {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Size(max = 255)
+    @NotNull
+    @Column(name = "text", nullable = false)
+    private String text;
+
+    @Size(max = 255)
+    @NotNull
+    @Column(name = "email", nullable = false)
+    private String email;
+
+}

--- a/qa-admin/src/main/java/ru/volpi/qaadmin/dto/question/Answer.java
+++ b/qa-admin/src/main/java/ru/volpi/qaadmin/dto/question/Answer.java
@@ -1,0 +1,16 @@
+package ru.volpi.qaadmin.dto.question;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class Answer {
+    private Long unknownQuestionId;
+    private String text;
+    private String category;
+}

--- a/qa-admin/src/main/java/ru/volpi/qaadmin/repository/UnknownQuestionRepository.java
+++ b/qa-admin/src/main/java/ru/volpi/qaadmin/repository/UnknownQuestionRepository.java
@@ -1,0 +1,7 @@
+package ru.volpi.qaadmin.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import ru.volpi.qaadmin.domain.question.UnknownQuestion;
+
+public interface UnknownQuestionRepository extends JpaRepository<UnknownQuestion, Long> {
+}

--- a/qa-admin/src/main/java/ru/volpi/qaadmin/service/QuestionService.java
+++ b/qa-admin/src/main/java/ru/volpi/qaadmin/service/QuestionService.java
@@ -1,5 +1,6 @@
 package ru.volpi.qaadmin.service;
 
+import ru.volpi.qaadmin.dto.question.Answer;
 import ru.volpi.qaadmin.dto.question.QuestionRegistration;
 import ru.volpi.qaadmin.dto.question.QuestionResponse;
 import ru.volpi.qaadmin.dto.question.QuestionUpdate;
@@ -19,4 +20,6 @@ public interface QuestionService {
     QuestionResponse save(QuestionRegistration registration);
 
     Long deleteById(Long id);
+
+    QuestionResponse addAnswer(Answer answer);
 }

--- a/qa-admin/src/main/java/ru/volpi/qaadmin/web/controller/QuestionsRestController.java
+++ b/qa-admin/src/main/java/ru/volpi/qaadmin/web/controller/QuestionsRestController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import ru.volpi.qaadmin.dto.category.CategoryResponse;
+import ru.volpi.qaadmin.dto.question.Answer;
 import ru.volpi.qaadmin.dto.question.QuestionRegistration;
 import ru.volpi.qaadmin.dto.question.QuestionUpdate;
 import ru.volpi.qaadmin.service.CategoryService;
@@ -65,5 +66,10 @@ public class QuestionsRestController {
     @DeleteMapping("/{id}")
     public ResponseEntity<?> deleteQuestionById(@PathVariable final Long id) {
         return ResponseEntity.status(HttpStatus.ACCEPTED).body(this.questionService.deleteById(id));
+    }
+
+    @PatchMapping("/answer")
+    public ResponseEntity<?> addAnswerToUnknownQuestion(@RequestBody final Answer answer) {
+        return ResponseEntity.status(HttpStatus.ACCEPTED).body(this.questionService.addAnswer(answer));
     }
 }

--- a/qa-admin/src/test/java/ru/volpi/qaadmin/service/impl/QuestionServiceImplTest.java
+++ b/qa-admin/src/test/java/ru/volpi/qaadmin/service/impl/QuestionServiceImplTest.java
@@ -4,11 +4,13 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import ru.volpi.qaadmin.TestcontainersTest;
+import ru.volpi.qaadmin.dto.question.Answer;
 import ru.volpi.qaadmin.dto.question.QuestionRegistration;
 import ru.volpi.qaadmin.dto.question.QuestionResponse;
 import ru.volpi.qaadmin.dto.question.QuestionUpdate;
 import ru.volpi.qaadmin.dto.question.QuestionsCategory;
 import ru.volpi.qaadmin.exception.question.QuestionNotFoundException;
+import ru.volpi.qaadmin.repository.UnknownQuestionRepository;
 import ru.volpi.qaadmin.service.CategoryService;
 import ru.volpi.qaadmin.service.QuestionService;
 
@@ -37,6 +39,9 @@ class QuestionServiceImplTest extends TestcontainersTest {
 
     @Autowired
     private CategoryService categoryService;
+
+    @Autowired
+    private UnknownQuestionRepository unknownQuestionRepository;
 
     @Test
     @DisplayName("Finds all questions")
@@ -111,5 +116,19 @@ class QuestionServiceImplTest extends TestcontainersTest {
             () -> this.questionService.findById(DELETION_QUESTION_ID),
             "Вопрос с id '%d' не найден!".formatted(DELETION_QUESTION_ID)
         );
+    }
+
+    @Test
+    @DisplayName("Adds answer to unknown question")
+    void sendsAnswer() {
+        final String answerPhrase = "Ответ на ваш вопрос";
+        final String secondCategory = "Вторая категория";
+        final QuestionResponse actual = this.questionService.addAnswer(
+            new Answer(111L, answerPhrase, secondCategory)
+        );
+        assertThat(this.unknownQuestionRepository.findById(111L).isPresent()).isFalse();
+        assertThat(actual.answer()).isEqualTo(answerPhrase);
+        assertThat(actual.text()).isEqualTo("Мой новый вопрос");
+        assertThat(actual.categoryName()).isEqualTo(secondCategory);
     }
 }

--- a/qa-admin/src/test/java/ru/volpi/qaadmin/web/controller/QuestionsRestControllerTest.java
+++ b/qa-admin/src/test/java/ru/volpi/qaadmin/web/controller/QuestionsRestControllerTest.java
@@ -33,6 +33,9 @@ class QuestionsRestControllerTest extends TestcontainersTest {
     private static final String SECOND_QUESTION_ID
         = "/api/v1/admin/questions/431";
 
+    private static final String ADD_ANSWER_URL
+        = "/api/v1/admin/questions/answer";
+
     @Autowired
     private MockMvc mockMvc;
 
@@ -109,5 +112,29 @@ class QuestionsRestControllerTest extends TestcontainersTest {
     void deletesQuestionById() throws Exception {
         this.mockMvc.perform(delete(SECOND_QUESTION_ID))
             .andExpect(status().isAccepted());
+    }
+
+    @Test
+    @WithMockUser("admin")
+    @DisplayName("Adds answer to unknown question")
+    void addsAnswerToUnknownQuestion() throws Exception {
+        final String response = this.mockMvc.perform(
+                patch(ADD_ANSWER_URL)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding(StandardCharsets.UTF_8)
+                    .content("""
+                        {
+                            "unknownQuestionId": 111,
+                            "text": "Ответ на вопрос",
+                            "category": "Первая категория"               
+                        }
+                        """)
+            ).andExpect(status().isAccepted())
+            .andReturn()
+            .getResponse()
+            .getContentAsString(StandardCharsets.UTF_8);
+        assertThat(response)
+            .containsIgnoringCase("ответ на вопрос")
+            .containsIgnoringCase("первая категория");
     }
 }

--- a/qa-admin/src/test/resources/sql/data.sql
+++ b/qa-admin/src/test/resources/sql/data.sql
@@ -11,3 +11,6 @@ VALUES (431, 3421, 'Вопрос уровня б', 'Ответ уровня б')
 
 INSERT INTO users_storage.users(id, username, password, role)
 VALUES (101, 'admin', '$2a$10$ecu/WLJDj7mQhXpa9lfJ0O/.NK38FeVtErsUPE8smP8bDHAXcs5vi', 'admin');
+
+INSERT INTO unknown_questions_storage.unknown_questions(id, text, email)
+VALUES (111, 'Мой новый вопрос', 'blah@gmail.com');


### PR DESCRIPTION
closes #151 
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary

This PR focuses on adding functionality to add an answer to an unknown question. The notable changes include:

- Added `Answer` class in `dto.question` package
- Added `addAnswer` method in `QuestionService` interface
- Implemented `addAnswer` method in `QuestionServiceImpl` class
- Added `addAnswerToUnknownQuestion` endpoint in `QuestionsRestController` class
- Added test cases for adding an answer in `QuestionsRestControllerTest` and `QuestionServiceImplTest` classes
- Added `UnknownQuestion` entity in `domain.question` package
- Added `UnknownQuestionRepository` interface in `repository` package
- Added SQL insert statement for unknown question in `data.sql` file

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->