### PR TITLE
Fixes email message

### DIFF
--- a/qa-rest/src/main/java/ru/volpi/qarest/repository/question/UnknownQuestionRepository.java
+++ b/qa-rest/src/main/java/ru/volpi/qarest/repository/question/UnknownQuestionRepository.java
@@ -6,5 +6,5 @@ import ru.volpi.qarest.domain.question.UnknownQuestion;
 
 @Repository
 public interface UnknownQuestionRepository extends JpaRepository<UnknownQuestion, Long> {
-    boolean existsByText(String text);
+    boolean existsByEmail(String email);
 }

--- a/qa-rest/src/main/java/ru/volpi/qarest/service/impl/UnknownQuestionServiceImpl.java
+++ b/qa-rest/src/main/java/ru/volpi/qarest/service/impl/UnknownQuestionServiceImpl.java
@@ -33,6 +33,9 @@ public class UnknownQuestionServiceImpl implements UnknownQuestionService {
     @Transactional
     @Override
     public ResponseDto save(final RegisterUnknownQuestion register) {
+        if (this.unknownQuestionRepository.existsByEmail(register.getEmail())) {
+            throw new QuestionAlreadyExistsException("Вы ужа задали вопрос, мы обрабатываем его");
+        }
         this.validate(register);
         this.unknownQuestionRepository.save(this.questionMapper.toEntity(register));
         return ResponseDto.builder()


### PR DESCRIPTION
closes #163 

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- The focus of this PR is to change the method in `UnknownQuestionRepository` from `existsByText` to `existsByEmail`.
- In `UnknownQuestionServiceImpl`, a new check is added to ensure that a question with the same email does not already exist before saving a new question. If it exists, a `QuestionAlreadyExistsException` is thrown.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->