### PR TITLE
Fixes email message

### DIFF
--- a/qa-rest/src/main/java/ru/volpi/qarest/exception/question/EmailAlreadyExistsException.java
+++ b/qa-rest/src/main/java/ru/volpi/qarest/exception/question/EmailAlreadyExistsException.java
@@ -1,0 +1,7 @@
+package ru.volpi.qarest.exception.question;
+
+public class EmailAlreadyExistsException extends RuntimeException {
+    public EmailAlreadyExistsException() {
+        super("Вы ужа задали вопрос, мы обрабатываем его");
+    }
+}

--- a/qa-rest/src/main/java/ru/volpi/qarest/service/impl/UnknownQuestionServiceImpl.java
+++ b/qa-rest/src/main/java/ru/volpi/qarest/service/impl/UnknownQuestionServiceImpl.java
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 import ru.volpi.qarest.common.Messages;
 import ru.volpi.qarest.dto.question.RegisterUnknownQuestion;
 import ru.volpi.qarest.dto.question.ResponseDto;
+import ru.volpi.qarest.exception.question.EmailAlreadyExistsException;
 import ru.volpi.qarest.exception.question.QuestionAlreadyExistsException;
 import ru.volpi.qarest.exception.question.QuestionValidationException;
 import ru.volpi.qarest.repository.question.QuestionRepository;
@@ -34,7 +35,7 @@ public class UnknownQuestionServiceImpl implements UnknownQuestionService {
     @Override
     public ResponseDto save(final RegisterUnknownQuestion register) {
         if (this.unknownQuestionRepository.existsByEmail(register.getEmail())) {
-            throw new QuestionAlreadyExistsException("Вы ужа задали вопрос, мы обрабатываем его");
+            throw new EmailAlreadyExistsException();
         }
         this.validate(register);
         this.unknownQuestionRepository.save(this.questionMapper.toEntity(register));

--- a/qa-rest/src/main/java/ru/volpi/qarest/web/handler/GlobalHandler.java
+++ b/qa-rest/src/main/java/ru/volpi/qarest/web/handler/GlobalHandler.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 import ru.volpi.qarest.exception.category.CategoryNotFoundException;
+import ru.volpi.qarest.exception.question.EmailAlreadyExistsException;
 import ru.volpi.qarest.exception.question.QuestionAlreadyExistsException;
 import ru.volpi.qarest.exception.question.QuestionNotFoundException;
 import ru.volpi.qarest.exception.question.QuestionValidationException;
@@ -44,6 +45,12 @@ public class GlobalHandler extends ResponseEntityExceptionHandler {
     @ExceptionHandler(QuestionAlreadyExistsException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public final ResponseEntity<?> onQuestionAlreadyExistsException(final QuestionAlreadyExistsException exc) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(exc.getMessage());
+    }
+
+    @ExceptionHandler(EmailAlreadyExistsException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public final ResponseEntity<?> onEmailAlreadyExistsException(final EmailAlreadyExistsException exc) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(exc.getMessage());
     }
 }


### PR DESCRIPTION
closes #163 

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Added a new exception class `EmailAlreadyExistsException` in the package `ru.volpi.qarest.exception.question`.
- Modified the `UnknownQuestionServiceImpl` class to throw the `EmailAlreadyExistsException` instead of `QuestionAlreadyExistsException` when a question with the same email already exists.
- Added a new exception handler method in the `GlobalHandler` class to handle the `EmailAlreadyExistsException` and return a bad request response.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->