### PR TITLE
Delete unknown question by id

### DIFF
--- a/qa-admin/src/main/java/ru/volpi/qaadmin/service/UnknownQuestionService.java
+++ b/qa-admin/src/main/java/ru/volpi/qaadmin/service/UnknownQuestionService.java
@@ -10,4 +10,6 @@ public interface UnknownQuestionService {
     QuestionResponse addAnswer(Answer answer);
 
     List<UnknownQuestionResponse> findAll();
+
+    void deleteById(Long id);
 }

--- a/qa-admin/src/main/java/ru/volpi/qaadmin/service/impl/UnknownQuestionServiceImpl.java
+++ b/qa-admin/src/main/java/ru/volpi/qaadmin/service/impl/UnknownQuestionServiceImpl.java
@@ -70,4 +70,9 @@ public class UnknownQuestionServiceImpl implements UnknownQuestionService {
             .map(question -> new UnknownQuestionResponse(question.getId(), question.getText()))
             .toList();
     }
+
+    @Override
+    public void deleteById(final Long id) {
+        this.unknownQuestionRepository.deleteById(id);
+    }
 }

--- a/qa-admin/src/main/java/ru/volpi/qaadmin/web/controller/QuestionsRestController.java
+++ b/qa-admin/src/main/java/ru/volpi/qaadmin/web/controller/QuestionsRestController.java
@@ -95,7 +95,7 @@ public class QuestionsRestController {
     }
 
     @Operation(summary = "Удалить вопрос от пользователя по id")
-    @DeleteMapping("/unknown")
+    @DeleteMapping("/unknown/{id}")
     public ResponseEntity<Void> deleteUnknownQuestionById(@PathVariable final Long id) {
         this.unknownQuestionService.deleteById(id);
         return ResponseEntity.accepted().build();

--- a/qa-admin/src/main/java/ru/volpi/qaadmin/web/controller/QuestionsRestController.java
+++ b/qa-admin/src/main/java/ru/volpi/qaadmin/web/controller/QuestionsRestController.java
@@ -94,6 +94,13 @@ public class QuestionsRestController {
         return ResponseEntity.ok(this.unknownQuestionService.findAll());
     }
 
+    @Operation(summary = "Удалить вопрос от пользователя по id")
+    @DeleteMapping("/unknown")
+    public ResponseEntity<Void> deleteUnknownQuestionById(@PathVariable final Long id) {
+        this.unknownQuestionService.deleteById(id);
+        return ResponseEntity.accepted().build();
+    }
+
     @Operation(summary = "Добавляет ответ к вопросу от пользователя и удаляет его из списка вопросов от пользователей")
     @PatchMapping("/answer")
     public ResponseEntity<QuestionResponse> addAnswerToUnknownQuestion(


### PR DESCRIPTION
closes #168

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on adding a delete operation for unknown questions in the QA Admin service.

### Detailed summary:
- Added `deleteById` method in `UnknownQuestionService` interface.
- Implemented `deleteById` method in `UnknownQuestionServiceImpl` class.
- Added `deleteUnknownQuestionById` method in `QuestionsRestController` class to handle the delete operation for unknown questions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->