### PR TITLE
171

### DIFF
--- a/qa-admin/src/main/java/ru/volpi/qaadmin/domain/question/UnknownQuestion.java
+++ b/qa-admin/src/main/java/ru/volpi/qaadmin/domain/question/UnknownQuestion.java
@@ -9,7 +9,10 @@ import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
+import lombok.NonNull;
 import lombok.Setter;
+
+import java.time.ZonedDateTime;
 
 @Getter
 @Setter
@@ -30,4 +33,7 @@ public class UnknownQuestion {
     @Column(name = "email", nullable = false)
     private String email;
 
+    @NonNull
+    @Column(name = "created_at", nullable = false)
+    private ZonedDateTime createdAt;
 }

--- a/qa-admin/src/main/java/ru/volpi/qaadmin/dto/category/CategoryName.java
+++ b/qa-admin/src/main/java/ru/volpi/qaadmin/dto/category/CategoryName.java
@@ -1,0 +1,4 @@
+package ru.volpi.qaadmin.dto.category;
+
+public record CategoryName(String value) {
+}

--- a/qa-admin/src/main/java/ru/volpi/qaadmin/dto/question/UnknownQuestionResponse.java
+++ b/qa-admin/src/main/java/ru/volpi/qaadmin/dto/question/UnknownQuestionResponse.java
@@ -1,4 +1,6 @@
 package ru.volpi.qaadmin.dto.question;
 
-public record UnknownQuestionResponse(Long id, String text) {
+import java.time.ZonedDateTime;
+
+public record UnknownQuestionResponse(Long id, String text, ZonedDateTime createdAt) {
 }

--- a/qa-admin/src/main/java/ru/volpi/qaadmin/repository/CategoryRepository.java
+++ b/qa-admin/src/main/java/ru/volpi/qaadmin/repository/CategoryRepository.java
@@ -1,9 +1,12 @@
 package ru.volpi.qaadmin.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import ru.volpi.qaadmin.domain.category.Category;
+import ru.volpi.qaadmin.dto.category.CategoryName;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -11,4 +14,7 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
     Optional<Category> findByNameIgnoreCase(String name);
 
     boolean existsByName(String name);
+
+    @Query("select name from Category")
+    List<String> findAllCategoriesNames();
 }

--- a/qa-admin/src/main/java/ru/volpi/qaadmin/service/CategoryService.java
+++ b/qa-admin/src/main/java/ru/volpi/qaadmin/service/CategoryService.java
@@ -1,5 +1,6 @@
 package ru.volpi.qaadmin.service;
 
+import ru.volpi.qaadmin.dto.category.CategoryName;
 import ru.volpi.qaadmin.dto.category.CategoryRegistration;
 import ru.volpi.qaadmin.dto.category.CategoryResponse;
 import ru.volpi.qaadmin.dto.category.CategoryUpdate;
@@ -19,4 +20,6 @@ public interface CategoryService {
     Long deleteById(Long id);
 
     Long categoryIdByName(String name);
+
+    List<CategoryName> findAllCategoriesNames();
 }

--- a/qa-admin/src/main/java/ru/volpi/qaadmin/service/impl/CategoryServiceImpl.java
+++ b/qa-admin/src/main/java/ru/volpi/qaadmin/service/impl/CategoryServiceImpl.java
@@ -7,6 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.annotation.Transactional;
 import ru.volpi.qaadmin.domain.category.Categories;
 import ru.volpi.qaadmin.domain.category.Category;
+import ru.volpi.qaadmin.dto.category.CategoryName;
 import ru.volpi.qaadmin.dto.category.CategoryRegistration;
 import ru.volpi.qaadmin.dto.category.CategoryResponse;
 import ru.volpi.qaadmin.dto.category.CategoryUpdate;
@@ -92,5 +93,13 @@ public class CategoryServiceImpl implements CategoryService {
         return this.categoryRepository.findByNameIgnoreCase(name)
             .map(Category::getId)
             .orElseThrow(() -> new CategoryNotFoundException(name));
+    }
+
+    @Override
+    public List<CategoryName> findAllCategoriesNames() {
+        return this.categoryRepository.findAllCategoriesNames()
+            .stream()
+            .map(CategoryName::new)
+            .toList();
     }
 }

--- a/qa-admin/src/main/java/ru/volpi/qaadmin/service/impl/UnknownQuestionServiceImpl.java
+++ b/qa-admin/src/main/java/ru/volpi/qaadmin/service/impl/UnknownQuestionServiceImpl.java
@@ -67,7 +67,12 @@ public class UnknownQuestionServiceImpl implements UnknownQuestionService {
     public List<UnknownQuestionResponse> findAll() {
         return this.unknownQuestionRepository.findAll()
             .stream()
-            .map(question -> new UnknownQuestionResponse(question.getId(), question.getText()))
-            .toList();
+            .map(
+                question -> new UnknownQuestionResponse(
+                    question.getId(),
+                    question.getText(),
+                    question.getCreatedAt()
+                )
+            ).toList();
     }
 }

--- a/qa-admin/src/main/java/ru/volpi/qaadmin/web/controller/CategoriesRestController.java
+++ b/qa-admin/src/main/java/ru/volpi/qaadmin/web/controller/CategoriesRestController.java
@@ -31,6 +31,11 @@ public class CategoriesRestController {
         return ResponseEntity.ok(this.categoryService.findAll());
     }
 
+    @GetMapping("/names")
+    public final ResponseEntity<?> allCategoriesNames() {
+        return ResponseEntity.ok(this.categoryService.findAllCategoriesNames());
+    }
+
     @GetMapping("/{name}")
     public final ResponseEntity<?> categoryByName(@PathVariable final String name) {
         return ResponseEntity.ok(this.categoryService.findCategoryByName(name));

--- a/qa-admin/src/main/resources/db/changelog/006-add-unknown-questions-created-at.sql
+++ b/qa-admin/src/main/resources/db/changelog/006-add-unknown-questions-created-at.sql
@@ -1,0 +1,2 @@
+ALTER TABLE IF EXISTS unknown_questions_storage.unknown_questions
+    ADD COLUMN created_at timestamp NOT NULL default clock_timestamp();

--- a/qa-admin/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/qa-admin/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -9,3 +9,5 @@ databaseChangeLog:
       file: db/changelog/004-add-user-role.sql
   - include:
       file: db/changelog/005-add-unknown-questions.sql
+  - include:
+      file: db/changelog/006-add-unknown-questions-created-at.sql

--- a/qa-rest/src/main/java/ru/volpi/qarest/common/Messages.java
+++ b/qa-rest/src/main/java/ru/volpi/qarest/common/Messages.java
@@ -5,5 +5,5 @@ import lombok.experimental.UtilityClass;
 @UtilityClass
 public class Messages {
     public static final String NEW_QUESTION_ADDED
-        = "Ваш вопрос '%s' добавлен, мы отправим письмо к Вам на почту, когда ответим на него!";
+        = "Ваш вопрос '%s' добавлен. Мы отправим письмо к Вам на почту, когда вопрос будет обработан!";
 }

--- a/qa-rest/src/main/java/ru/volpi/qarest/domain/question/UnknownQuestion.java
+++ b/qa-rest/src/main/java/ru/volpi/qarest/domain/question/UnknownQuestion.java
@@ -12,8 +12,11 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.NonNull;
 import lombok.Setter;
 import lombok.ToString;
+
+import java.time.ZonedDateTime;
 
 @Entity
 @Table(name = "unknown_questions", schema = "unknown_questions_storage")
@@ -37,5 +40,8 @@ public class UnknownQuestion {
     @NotNull
     @Column(name = "email", nullable = false)
     private String email;
+
+    @Column(name = "created_at", nullable = true)
+    private ZonedDateTime createdAt;
 
 }

--- a/qa-rest/src/main/java/ru/volpi/qarest/dto/category/CategoryName.java
+++ b/qa-rest/src/main/java/ru/volpi/qarest/dto/category/CategoryName.java
@@ -1,0 +1,4 @@
+package ru.volpi.qarest.dto.category;
+
+public record CategoryName(String value) {
+}

--- a/qa-rest/src/main/java/ru/volpi/qarest/repository/category/CategoryRepository.java
+++ b/qa-rest/src/main/java/ru/volpi/qarest/repository/category/CategoryRepository.java
@@ -1,12 +1,17 @@
 package ru.volpi.qarest.repository.category;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import ru.volpi.qarest.domain.category.Category;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface CategoryRepository extends JpaRepository<Category, Long> {
     Optional<Category> findCategoryByNameIgnoreCase(String name);
+
+    @Query("select name from Category")
+    List<String> findAllCategoriesNames();
 }

--- a/qa-rest/src/main/java/ru/volpi/qarest/service/ReadCategoryService.java
+++ b/qa-rest/src/main/java/ru/volpi/qarest/service/ReadCategoryService.java
@@ -1,5 +1,6 @@
 package ru.volpi.qarest.service;
 
+import ru.volpi.qarest.dto.category.CategoryName;
 import ru.volpi.qarest.dto.category.CategoryResponse;
 
 import java.util.List;
@@ -11,4 +12,6 @@ public interface ReadCategoryService {
     CategoryResponse findCategoryByName(String name);
 
     List<CategoryResponse> findAllCategories();
+
+    List<CategoryName> findAllCategoriesNames();
 }

--- a/qa-rest/src/main/java/ru/volpi/qarest/service/impl/ReadCategoryServiceImpl.java
+++ b/qa-rest/src/main/java/ru/volpi/qarest/service/impl/ReadCategoryServiceImpl.java
@@ -3,6 +3,7 @@ package ru.volpi.qarest.service.impl;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.annotation.Transactional;
+import ru.volpi.qarest.dto.category.CategoryName;
 import ru.volpi.qarest.dto.category.CategoryResponse;
 import ru.volpi.qarest.exception.category.CategoryNotFoundException;
 import ru.volpi.qarest.repository.category.CategoryRepository;
@@ -39,5 +40,13 @@ public class ReadCategoryServiceImpl implements ReadCategoryService {
     public List<CategoryResponse> findAllCategories() {
         return this.categoryRepository.findAll()
             .stream().map(CategoryResponse::from).toList();
+    }
+
+    @Override
+    public List<CategoryName> findAllCategoriesNames() {
+        return this.categoryRepository.findAllCategoriesNames()
+            .stream()
+            .map(CategoryName::new)
+            .toList();
     }
 }

--- a/qa-rest/src/main/java/ru/volpi/qarest/service/impl/UnknownQuestionServiceImpl.java
+++ b/qa-rest/src/main/java/ru/volpi/qarest/service/impl/UnknownQuestionServiceImpl.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import ru.volpi.qarest.common.Messages;
+import ru.volpi.qarest.domain.question.UnknownQuestion;
 import ru.volpi.qarest.dto.question.RegisterUnknownQuestion;
 import ru.volpi.qarest.dto.question.ResponseDto;
 import ru.volpi.qarest.exception.question.EmailAlreadyExistsException;
@@ -16,6 +17,8 @@ import ru.volpi.qarest.repository.question.UnknownQuestionRepository;
 import ru.volpi.qarest.service.UnknownQuestionService;
 import ru.volpi.qarest.service.mapper.UnknownQuestionMapper;
 
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.Set;
 
 @Service
@@ -38,7 +41,13 @@ public class UnknownQuestionServiceImpl implements UnknownQuestionService {
             throw new EmailAlreadyExistsException();
         }
         this.validate(register);
-        this.unknownQuestionRepository.save(this.questionMapper.toEntity(register));
+        final UnknownQuestion question = this.questionMapper.toEntity(register);
+        question.setCreatedAt(
+            ZonedDateTime.now().withZoneSameLocal(
+                ZoneId.of("Europe/Moscow")
+            )
+        );
+        this.unknownQuestionRepository.save(question);
         return ResponseDto.builder()
             .text(Messages.NEW_QUESTION_ADDED.formatted(register.getText()))
             .build();

--- a/qa-rest/src/main/java/ru/volpi/qarest/service/mapper/UnknownQuestionMapper.java
+++ b/qa-rest/src/main/java/ru/volpi/qarest/service/mapper/UnknownQuestionMapper.java
@@ -1,10 +1,11 @@
 package ru.volpi.qarest.service.mapper;
 
 import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
 import ru.volpi.qarest.domain.question.UnknownQuestion;
 import ru.volpi.qarest.dto.question.RegisterUnknownQuestion;
 
-@Mapper(componentModel = "spring")
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface UnknownQuestionMapper {
-    UnknownQuestion toEntity(final RegisterUnknownQuestion register);
+    UnknownQuestion toEntity(RegisterUnknownQuestion register);
 }

--- a/qa-rest/src/main/java/ru/volpi/qarest/web/controller/CategoriesController.java
+++ b/qa-rest/src/main/java/ru/volpi/qarest/web/controller/CategoriesController.java
@@ -7,7 +7,10 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import ru.volpi.qarest.dto.category.CategoryName;
 import ru.volpi.qarest.service.ReadCategoryService;
+
+import java.util.List;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -30,5 +33,10 @@ public class CategoriesController {
     @GetMapping("/{id}")
     public final ResponseEntity<?> categoryById(@PathVariable final Long id) {
         return ResponseEntity.ok(this.categoryService.findCategoryById(id));
+    }
+
+    @GetMapping("/names")
+    public final ResponseEntity<List<CategoryName>> allCategoriesNames() {
+        return ResponseEntity.ok(this.categoryService.findAllCategoriesNames());
     }
 }

--- a/qa-rest/src/test/resources/db/changelog/006-add-unknown-questions-created-at.sql
+++ b/qa-rest/src/test/resources/db/changelog/006-add-unknown-questions-created-at.sql
@@ -1,0 +1,2 @@
+ALTER TABLE IF EXISTS unknown_questions_storage.unknown_questions
+    ADD COLUMN created_at timestamp NOT NULL default clock_timestamp();

--- a/qa-rest/src/test/resources/db/changelog/db.changelog-master.yaml
+++ b/qa-rest/src/test/resources/db/changelog/db.changelog-master.yaml
@@ -9,3 +9,5 @@ databaseChangeLog:
       file: db/changelog/004-add-user-role.sql
   - include:
       file: db/changelog/005-add-unknown-questions.sql
+  - include:
+      file: db/changelog/006-add-unknown-questions-created-at.sql


### PR DESCRIPTION
closes #170, closes #171

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Added `CategoryName` record class in both `qa-rest` and `qa-admin` modules.
- Modified the database changelog files to include a new SQL script for adding a column `created_at` to the `unknown_questions` table.
- Modified the `UnknownQuestionResponse` class in `qa-admin` module to include a new field `createdAt`.
- Modified the `Messages` class in `qa-rest` module to update the message format.
- Modified the `UnknownQuestionServiceImpl` class in `qa-admin` module to include the `createdAt` field when mapping `UnknownQuestion` to `UnknownQuestionResponse`.
- Added a new method `findAllCategoriesNames()` in both `CategoryService` and `ReadCategoryService` interfaces and their respective implementations to retrieve a list of category names.
- Modified the `CategoriesRestController` class in `qa-admin` module to include a new endpoint for retrieving all category names.
- Modified the `CategoryRepository` interface in both `qa-admin` and `qa-rest` modules to include a new query method for retrieving all category names.
- Modified the `UnknownQuestionMapper` interface in `qa-rest` module to ignore unmapped properties.
- Modified the `UnknownQuestion` class in `qa-rest` module to include a new field `createdAt`.
- Modified the `ReadCategoryServiceImpl` class in `qa-rest` module to include the `findAllCategoriesNames()` method.
- Modified the `CategoriesController` class in `qa-rest` module to include a new endpoint for retrieving all category names.
- Modified the `UnknownQuestionServiceImpl` class in `qa-rest` module to set the `createdAt` field with the current timestamp when saving a new `UnknownQuestion` record.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->