### PR TITLE
173

### DIFF
--- a/qa-admin/src/main/java/ru/volpi/qaadmin/dto/question/AnsweredQuestion.java
+++ b/qa-admin/src/main/java/ru/volpi/qaadmin/dto/question/AnsweredQuestion.java
@@ -9,8 +9,9 @@ import lombok.NoArgsConstructor;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class Answer {
+public class AnsweredQuestion {
     private Long unknownQuestionId;
     private String text;
+    private String answer;
     private String category;
 }

--- a/qa-admin/src/main/java/ru/volpi/qaadmin/repository/CategoryRepository.java
+++ b/qa-admin/src/main/java/ru/volpi/qaadmin/repository/CategoryRepository.java
@@ -4,7 +4,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import ru.volpi.qaadmin.domain.category.Category;
-import ru.volpi.qaadmin.dto.category.CategoryName;
 
 import java.util.List;
 import java.util.Optional;

--- a/qa-admin/src/main/java/ru/volpi/qaadmin/service/UnknownQuestionService.java
+++ b/qa-admin/src/main/java/ru/volpi/qaadmin/service/UnknownQuestionService.java
@@ -1,13 +1,13 @@
 package ru.volpi.qaadmin.service;
 
-import ru.volpi.qaadmin.dto.question.Answer;
+import ru.volpi.qaadmin.dto.question.AnsweredQuestion;
 import ru.volpi.qaadmin.dto.question.QuestionResponse;
 import ru.volpi.qaadmin.dto.question.UnknownQuestionResponse;
 
 import java.util.List;
 
 public interface UnknownQuestionService {
-    QuestionResponse addAnswer(Answer answer);
+    QuestionResponse addAnswer(AnsweredQuestion answeredQuestion);
 
     List<UnknownQuestionResponse> findAll();
 

--- a/qa-admin/src/main/java/ru/volpi/qaadmin/service/impl/UnknownQuestionServiceImpl.java
+++ b/qa-admin/src/main/java/ru/volpi/qaadmin/service/impl/UnknownQuestionServiceImpl.java
@@ -5,7 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import ru.volpi.qaadmin.domain.question.Question;
-import ru.volpi.qaadmin.dto.question.Answer;
+import ru.volpi.qaadmin.dto.question.AnsweredQuestion;
 import ru.volpi.qaadmin.dto.question.QuestionResponse;
 import ru.volpi.qaadmin.dto.question.UnknownQuestionResponse;
 import ru.volpi.qaadmin.exception.category.CategoryNotFoundException;
@@ -33,32 +33,32 @@ public class UnknownQuestionServiceImpl implements UnknownQuestionService {
 
     @Transactional
     @Override
-    public QuestionResponse addAnswer(final Answer answer) {
-        log.info("Answer came {}", answer);
+    public QuestionResponse addAnswer(final AnsweredQuestion answeredQuestion) {
+        log.info("Answer came {}", answeredQuestion);
         return QuestionResponse.from(
-            this.unknownQuestionRepository.findById(answer.getUnknownQuestionId())
+            this.unknownQuestionRepository.findById(answeredQuestion.getUnknownQuestionId())
                 .map(
                     question -> {
                         final Question answered = this.questionRepository.save(
                             Question.builder()
-                                .text(question.getText())
-                                .answer(answer.getText())
+                                .text(answeredQuestion.getText())
+                                .answer(answeredQuestion.getAnswer())
                                 .category(
-                                    this.categoryRepository.findByNameIgnoreCase(answer.getCategory())
-                                        .orElseThrow(() -> new CategoryNotFoundException(answer.getCategory()))
+                                    this.categoryRepository.findByNameIgnoreCase(answeredQuestion.getCategory())
+                                        .orElseThrow(() -> new CategoryNotFoundException(answeredQuestion.getCategory()))
                                 )
                                 .build()
                         );
-                        this.unknownQuestionRepository.deleteById(answer.getUnknownQuestionId());
+                        this.unknownQuestionRepository.deleteById(answeredQuestion.getUnknownQuestionId());
                         this.emailService.sendNotification(
                             question.getEmail(),
                             "Ответ на Ваш вопрос добавлен",
-                            question.getText()
+                            answeredQuestion.getText()
                         );
-                        log.info("Answer {} added", answer);
+                        log.info("Answer {} added", answeredQuestion);
                         return answered;
                     }
-                ).orElseThrow(() -> new QuestionNotFoundException(answer.getUnknownQuestionId()))
+                ).orElseThrow(() -> new QuestionNotFoundException(answeredQuestion.getUnknownQuestionId()))
         );
     }
 

--- a/qa-admin/src/main/java/ru/volpi/qaadmin/web/controller/QuestionsRestController.java
+++ b/qa-admin/src/main/java/ru/volpi/qaadmin/web/controller/QuestionsRestController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import ru.volpi.qaadmin.dto.category.CategoryResponse;
-import ru.volpi.qaadmin.dto.question.Answer;
+import ru.volpi.qaadmin.dto.question.AnsweredQuestion;
 import ru.volpi.qaadmin.dto.question.QuestionRegistration;
 import ru.volpi.qaadmin.dto.question.QuestionResponse;
 import ru.volpi.qaadmin.dto.question.QuestionUpdate;
@@ -105,8 +105,8 @@ public class QuestionsRestController {
     @PatchMapping("/answer")
     public ResponseEntity<QuestionResponse> addAnswerToUnknownQuestion(
         @Parameter(name = "Ответ на вопрос")
-        @RequestBody final Answer answer
+        @RequestBody final AnsweredQuestion answeredQuestion
     ) {
-        return ResponseEntity.status(HttpStatus.ACCEPTED).body(this.unknownQuestionService.addAnswer(answer));
+        return ResponseEntity.status(HttpStatus.ACCEPTED).body(this.unknownQuestionService.addAnswer(answeredQuestion));
     }
 }

--- a/qa-admin/src/test/java/ru/volpi/qaadmin/service/impl/QuestionServiceImplTest.java
+++ b/qa-admin/src/test/java/ru/volpi/qaadmin/service/impl/QuestionServiceImplTest.java
@@ -4,13 +4,11 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import ru.volpi.qaadmin.TestcontainersTest;
-import ru.volpi.qaadmin.dto.question.Answer;
 import ru.volpi.qaadmin.dto.question.QuestionRegistration;
 import ru.volpi.qaadmin.dto.question.QuestionResponse;
 import ru.volpi.qaadmin.dto.question.QuestionUpdate;
 import ru.volpi.qaadmin.dto.question.QuestionsCategory;
 import ru.volpi.qaadmin.exception.question.QuestionNotFoundException;
-import ru.volpi.qaadmin.repository.UnknownQuestionRepository;
 import ru.volpi.qaadmin.service.CategoryService;
 import ru.volpi.qaadmin.service.QuestionService;
 

--- a/qa-admin/src/test/java/ru/volpi/qaadmin/service/impl/UnknownQuestionServiceImplTest.java
+++ b/qa-admin/src/test/java/ru/volpi/qaadmin/service/impl/UnknownQuestionServiceImplTest.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import ru.volpi.qaadmin.TestcontainersTest;
-import ru.volpi.qaadmin.dto.question.Answer;
+import ru.volpi.qaadmin.dto.question.AnsweredQuestion;
 import ru.volpi.qaadmin.dto.question.QuestionResponse;
 import ru.volpi.qaadmin.repository.UnknownQuestionRepository;
 
@@ -23,12 +23,13 @@ class UnknownQuestionServiceImplTest extends TestcontainersTest {
     void addsAnswer() {
         final String answerPhrase = "Ответ на ваш вопрос";
         final String secondCategory = "Вторая категория";
+        final String questionText = "Мой новый вопрос";
         final QuestionResponse actual = this.unknownService.addAnswer(
-            new Answer(111L, answerPhrase, secondCategory)
+            new AnsweredQuestion(111L, questionText, answerPhrase, secondCategory)
         );
         assertThat(this.unknownQuestionRepository.findById(111L).isPresent()).isFalse();
         assertThat(actual.answer()).isEqualTo(answerPhrase);
-        assertThat(actual.text()).isEqualTo("Мой новый вопрос");
+        assertThat(actual.text()).isEqualTo(questionText);
         assertThat(actual.categoryName()).isEqualTo(secondCategory);
     }
 

--- a/qa-admin/src/test/java/ru/volpi/qaadmin/web/controller/QuestionsRestControllerTest.java
+++ b/qa-admin/src/test/java/ru/volpi/qaadmin/web/controller/QuestionsRestControllerTest.java
@@ -116,7 +116,7 @@ class QuestionsRestControllerTest extends TestcontainersTest {
 
     @Test
     @WithMockUser("admin")
-    @DisplayName("Adds answer to unknown question")
+    @DisplayName("Adds answeredQuestion to unknown question")
     void addsAnswerToUnknownQuestion() throws Exception {
         final String response = this.mockMvc.perform(
                 patch(ADD_ANSWER_URL)
@@ -125,7 +125,8 @@ class QuestionsRestControllerTest extends TestcontainersTest {
                     .content("""
                         {
                             "unknownQuestionId": 111,
-                            "text": "Ответ на вопрос",
+                            "text": "Мой новый вопрос",
+                            "answer": "Ответ на вопрос",
                             "category": "Первая категория"              
                         }
                         """)

--- a/qa-rest/src/main/java/ru/volpi/qarest/config/ApiCorsConfiguration.java
+++ b/qa-rest/src/main/java/ru/volpi/qarest/config/ApiCorsConfiguration.java
@@ -16,7 +16,7 @@ public class ApiCorsConfiguration {
                 registry
                     .addMapping("/**")
                     .allowedOrigins("*")
-                    .allowedMethods("GET","POST", "PUT", "PATCH")
+                    .allowedMethods("GET", "POST", "PUT", "PATCH")
                     .allowedHeaders("*");
             }
         };

--- a/qa-rest/src/main/java/ru/volpi/qarest/domain/question/UnknownQuestion.java
+++ b/qa-rest/src/main/java/ru/volpi/qarest/domain/question/UnknownQuestion.java
@@ -12,7 +12,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.NonNull;
 import lombok.Setter;
 import lombok.ToString;
 


### PR DESCRIPTION
closes #173 

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary

- Renamed `Answer` class to `AnsweredQuestion` in multiple files.
- Updated method signatures and variable names to reflect the change.
- Modified code to use `AnsweredQuestion` instead of `Answer` in the `UnknownQuestionService` interface.
- Updated test cases to use `AnsweredQuestion` instead of `Answer`.
- Modified code in `UnknownQuestionServiceImpl` to use `AnsweredQuestion` instead of `Answer`.
- Updated method parameters and variable names in `QuestionsRestController` to use `AnsweredQuestion` instead of `Answer`.
- Updated test cases in `QuestionsRestControllerTest` and `UnknownQuestionServiceImplTest` to use `AnsweredQuestion` instead of `Answer`.
- Removed unused import `ru.volpi.qaadmin.dto.category.CategoryName` in `CategoryRepository`.
- Updated `ApiCorsConfiguration` to use correct syntax for `allowedMethods` in `addMapping` method.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->