### PR TITLE
List of strings instead of objects

### DIFF
--- a/qa-admin/src/main/java/ru/volpi/qaadmin/service/CategoryService.java
+++ b/qa-admin/src/main/java/ru/volpi/qaadmin/service/CategoryService.java
@@ -21,5 +21,5 @@ public interface CategoryService {
 
     Long categoryIdByName(String name);
 
-    List<CategoryName> findAllCategoriesNames();
+    List<String> findAllCategoriesNames();
 }

--- a/qa-admin/src/main/java/ru/volpi/qaadmin/service/impl/CategoryServiceImpl.java
+++ b/qa-admin/src/main/java/ru/volpi/qaadmin/service/impl/CategoryServiceImpl.java
@@ -96,10 +96,7 @@ public class CategoryServiceImpl implements CategoryService {
     }
 
     @Override
-    public List<CategoryName> findAllCategoriesNames() {
-        return this.categoryRepository.findAllCategoriesNames()
-            .stream()
-            .map(CategoryName::new)
-            .toList();
+    public List<String> findAllCategoriesNames() {
+        return this.categoryRepository.findAllCategoriesNames();
     }
 }

--- a/qa-rest/src/main/java/ru/volpi/qarest/service/ReadCategoryService.java
+++ b/qa-rest/src/main/java/ru/volpi/qarest/service/ReadCategoryService.java
@@ -13,5 +13,5 @@ public interface ReadCategoryService {
 
     List<CategoryResponse> findAllCategories();
 
-    List<CategoryName> findAllCategoriesNames();
+    List<String> findAllCategoriesNames();
 }

--- a/qa-rest/src/main/java/ru/volpi/qarest/service/impl/ReadCategoryServiceImpl.java
+++ b/qa-rest/src/main/java/ru/volpi/qarest/service/impl/ReadCategoryServiceImpl.java
@@ -3,7 +3,6 @@ package ru.volpi.qarest.service.impl;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.annotation.Transactional;
-import ru.volpi.qarest.dto.category.CategoryName;
 import ru.volpi.qarest.dto.category.CategoryResponse;
 import ru.volpi.qarest.exception.category.CategoryNotFoundException;
 import ru.volpi.qarest.repository.category.CategoryRepository;
@@ -43,10 +42,7 @@ public class ReadCategoryServiceImpl implements ReadCategoryService {
     }
 
     @Override
-    public List<CategoryName> findAllCategoriesNames() {
-        return this.categoryRepository.findAllCategoriesNames()
-            .stream()
-            .map(CategoryName::new)
-            .toList();
+    public List<String> findAllCategoriesNames() {
+        return this.categoryRepository.findAllCategoriesNames();
     }
 }

--- a/qa-rest/src/main/java/ru/volpi/qarest/web/controller/CategoriesController.java
+++ b/qa-rest/src/main/java/ru/volpi/qarest/web/controller/CategoriesController.java
@@ -36,7 +36,7 @@ public class CategoriesController {
     }
 
     @GetMapping("/names")
-    public final ResponseEntity<List<CategoryName>> allCategoriesNames() {
+    public final ResponseEntity<List<String>> allCategoriesNames() {
         return ResponseEntity.ok(this.categoryService.findAllCategoriesNames());
     }
 }


### PR DESCRIPTION
closes #195 

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
This PR focuses on changing the return type of the `findAllCategoriesNames()` method from `List<CategoryName>` to `List<String>` in multiple files.

### Detailed summary:
- Changed the return type of the `findAllCategoriesNames()` method in `CategoryService.java` from `List<CategoryName>` to `List<String>`.
- Changed the return type of the `findAllCategoriesNames()` method in `ReadCategoryService.java` from `List<CategoryName>` to `List<String>`.
- Changed the return type of the `allCategoriesNames()` method in `CategoriesController.java` from `ResponseEntity<List<CategoryName>>` to `ResponseEntity<List<String>>`.
- Changed the implementation of the `findAllCategoriesNames()` method in `CategoryServiceImpl.java` to return a `List<String>` instead of mapping it to `List<CategoryName>`.
- Changed the implementation of the `findAllCategoriesNames()` method in `ReadCategoryServiceImpl.java` to return a `List<String>` instead of mapping it to `List<CategoryName>`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->