### PR TITLE
add handling for error on load categories (#143)

### DIFF
--- a/qa-rest/src/main/client/src/components/views/DefaultView.tsx
+++ b/qa-rest/src/main/client/src/components/views/DefaultView.tsx
@@ -20,9 +20,14 @@ export const DefaultView: FC = () => {
             </div>
             <div className={"font-semibold text-lg px-4 pt-4 pb-3 sticky border-b -top-1 bg-white/50 backdrop-blur-sm z-10"}>Категории:</div>
             <div className={"space-y-4 px-4 pt-4"}>
-                {categories.map((category) => (
-                    <CategoryOption key={category.id} category={category}/>
-                ))}
+                {loading === "succeeded"
+                    ? categories.map((category) => (
+                        <CategoryOption key={category.id} category={category}/>
+                    ))
+                    : <div>
+                        Какая жалость, категории кто-то украл <span className={"text-xl"}>😢</span>
+                    </div>
+                }
             </div>
         </>
     )


### PR DESCRIPTION
Closes #143

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Added conditional rendering to display a message if the loading of categories fails.
- If `loading` is "succeeded", the categories will be displayed as before.
- If `loading` is not "succeeded", a message will be displayed indicating that the categories have been stolen.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->